### PR TITLE
show error message details in connection failures

### DIFF
--- a/lib/DevAPI/Session.js
+++ b/lib/DevAPI/Session.js
@@ -257,14 +257,15 @@ function _cleanup () {
 /**
  * Loop through failover addresses.
  * @private
+ * @param {Error} err
  */
-function _failover () {
+function _failover (err) {
     const index = this._properties.connection + 1;
 
     if (!this._properties.endpoints[index]) {
         _setActiveConnection.call(this, 0);
-
-        const error = new Error('All routers failed.');
+        const message = 'All routers failed: ' + err.message;
+        const error = new Error(message);
         error.errno = 4001;
 
         throw error;


### PR DESCRIPTION
The current message on connection failures is just "All routers failed", which has no information to debug.

This PR adds error details to it, for example:

> Error: All routers failed: connect ECONNREFUSED 127.0.0.1:33060

Thanks.