### PR TITLE
Better value check

### DIFF
--- a/lib/DevAPI/Util/parseFlexibleParamList.js
+++ b/lib/DevAPI/Util/parseFlexibleParamList.js
@@ -36,7 +36,7 @@ module.exports = function (paramList) {
     }, []);
 
     const invalid = result.filter(field => {
-        return !field || typeof field === 'function';
+        return typeof field === 'undefined' || typeof field === 'function';
     });
 
     if (invalid.length) {

--- a/lib/DevAPI/Util/parseFlexibleParamList.js
+++ b/lib/DevAPI/Util/parseFlexibleParamList.js
@@ -36,7 +36,7 @@ module.exports = function (paramList) {
     }, []);
 
     const invalid = result.filter(field => {
-        return typeof field === 'undefined' || typeof field === 'function';
+        return typeof field === 'undefined' || field === null || typeof field === 'function';
     });
 
     if (invalid.length) {

--- a/test/unit/DevAPI/Util/parseFlexibleParamList.js
+++ b/test/unit/DevAPI/Util/parseFlexibleParamList.js
@@ -16,6 +16,7 @@ describe('parseFlexibleParamList', () => {
 
     it('should throw an error if an expression is not valid', () => {
         expect(function () { parseFlexibleParamList([undefined]); }).to.throw(Error, 'invalid input expression');
+        expect(function () { parseFlexibleParamList([null]); }).to.throw(Error, 'invalid input expression');
     });
 
     it('should not throw an error if the expression is zero', () => {

--- a/test/unit/DevAPI/Util/parseFlexibleParamList.js
+++ b/test/unit/DevAPI/Util/parseFlexibleParamList.js
@@ -17,4 +17,12 @@ describe('parseFlexibleParamList', () => {
     it('should throw an error if an expression is not valid', () => {
         expect(function () { parseFlexibleParamList([undefined]); }).to.throw(Error, 'invalid input expression');
     });
+
+    it('should not throw an error if the expression is zero', () => {
+        expect(function () { parseFlexibleParamList([0]); }).to.not.throw(Error, 'invalid input expression');
+    });
+
+    it('should not throw an error if the expression is false', () => {
+        expect(function () { parseFlexibleParamList([false]); }).to.not.throw(Error, 'invalid input expression');
+    })
 });


### PR DESCRIPTION
Cannot use `TableInsert.values` with a valid falsey value such as the number 0.
This will change the verification test from checking for falsey values (0, false, empty string, undefined, null) to checking for undefined and null, allowing for values that JavaScript considers falsey (0, empty string)