### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ There are a few ways to contribute to the Connector/Node.js code. Please refer t
 * [MySQL Connector/Node.js forum](http://forums.mysql.com/list.php?44)
 * [`#connectors` channel in MySQL Community Slack](https://mysqlcommunity.slack.com/messages/connectors) ([Sign-up](https://lefred.be/mysql-community-on-slack/) required when not using an Oracle account)
 * [Twitter](https://twitter.com/mysql)
-* [InsideMySQL.com Connectors Blog](https://insidemysql.com/category/mysql-development/connectors/)
 * [MySQL Public Bug Tracker](https://bugs.mysql.com/)
 
 For more information about this and other MySQL products, please visit [MySQL Contact & Questions](https://www.mysql.com/about/contact/).


### PR DESCRIPTION
link broken for "InsideMySQL.com Connectors Blog"
It redirects to https://blogs.oracle.com/mysql/category/mysql-development/connectors and show page not found